### PR TITLE
Added a setting for an custom ip/hostname

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -43,6 +43,8 @@ namespace CoverMe
 		bool lowFPSmode = false;
 		bool enableLogging = false;
 		
+		String hostname = "localhost";
+		
 		public MainForm()
 		{
 			InitializeComponent();
@@ -74,6 +76,9 @@ namespace CoverMe
 				
 				lowFPSmode = Boolean.Parse(Properties.GetSetting("LowFpsMode", "False"));
 				Logger.log("Loaded setting LowFpsMode=" + lowFPSmode.ToString());
+				
+				hostname = Properties.GetSetting("hostname", "localhost");
+				Logger.log("Loaded setting hostname=" + hostname);
 				
 				SpecialKeyHelper.StrokeDelay = lowFPSmode ? 200 : 50;
 				
@@ -148,7 +153,7 @@ namespace CoverMe
 			try {
 				Logger.log("Querying JSON-file for indicators");
 				
-				string content = RemoteFile.Fetch("http://localhost:8111/indicators");
+				string content = RemoteFile.Fetch("http://"+hostname+":8111/indicators");
 
 				Logger.log("Succesfully retrieved JSON-file");
 				

--- a/Settings.txt
+++ b/Settings.txt
@@ -50,4 +50,11 @@ SimpleTriggerKeys=VK_Z
 # Change to 'True' if you are experiencing errors or bugs and want to send me a
 # bug report with the log.
 
-EnableLogging=False
+EnableLogging=True
+
+# The following setting allows you to specify a (different) hostname or IP for the
+# WarThunder web-service
+# default is "localhost"
+# In some cases, using an ip may improve performance by a tiny bit.
+
+hostname=localhost


### PR DESCRIPTION
This allows the user to set a custom hostname/ip.
Since windows 8 or 10 "localhost" is not included in the host.etc file anymore.
This leads to a DNS request for "localhost" at the set DNS server and therefore results in a small delay.
Using a direct IP resolves this.
