### PR TITLE
Added Functionality to display the direction with a variable detail

### DIFF
--- a/IndicatorsData.cs
+++ b/IndicatorsData.cs
@@ -73,5 +73,32 @@ namespace CoverMe
 		public int getHeading() {
 			return (int)this.compass;
 		}
+		
+		
+		/// <summary>
+		/// Array of directions clockwise beginning with north (N to NNW)
+		/// </summary>
+	    static String[] directions = {"N","NNE","NE","ENE","E","ESE","SE","SSE","S","SSW","SW","WSW","W","WNW","NW","NNW"};    
+	    
+	    /// <summary>
+		/// Returns a direction based on the heading
+		/// </summary>
+		/// <param name="detail">the level of detail 0=null 1=N 2=NW 3=NNW</param>
+		/// <returns>1-3 character string</returns>
+   		public string getAdvancedHeading(int detail){
+			//filter invalid detail level
+	    	if(detail==0 || detail > 3)
+	    		return null;
+	    	
+	    	int factor = (int) Math.Pow(2,3-(detail));
+	    	// calculate array Index for HDG
+	    	int index = (int) Math.Round((this.compass) / (360/(directions.Length/factor)));
+	      
+	    	//Prevent Out of bounds
+	        if(index > directions.Length/factor)
+	            index-=directions.Length/factor;
+	     
+        	return directions[index*factor];
+   		}
 	}
 }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -43,6 +43,8 @@ namespace CoverMe
 		bool lowFPSmode = false;
 		bool enableLogging = false;
 		
+		int preciseHDG = 3;
+		
 		public MainForm()
 		{
 			InitializeComponent();
@@ -74,6 +76,10 @@ namespace CoverMe
 				
 				lowFPSmode = Boolean.Parse(Properties.GetSetting("LowFpsMode", "False"));
 				Logger.log("Loaded setting LowFpsMode=" + lowFPSmode.ToString());
+				
+				preciseHDG = Int32.Parse(Properties.GetSetting("PreciseHDG", "3"));
+				Logger.log("Loaded setting PreciseHDG=" + preciseHDG.ToString());
+				
 				
 				SpecialKeyHelper.StrokeDelay = lowFPSmode ? 200 : 50;
 				
@@ -191,6 +197,12 @@ namespace CoverMe
 					{
 						sb.Append(" HDG ");
 						sb.Append(hdg);
+						
+						if(preciseHDG > 0){
+							sb.AppendFormat("({0})",data.getAdvancedHeading(preciseHDG));
+						}else{
+							Logger.log("-> AdvancedHeading        = Disabled (Or over 3)");
+						}
 					}
 					else
 					{

--- a/Settings.txt
+++ b/Settings.txt
@@ -51,3 +51,13 @@ SimpleTriggerKeys=VK_Z
 # bug report with the log.
 
 EnableLogging=False
+
+# This setting enables the output of Additional Direction text following the heading degrees
+# i.e.: N,S,W,E,NE,SE,SSE ...
+#
+# 0 = Disabled
+# 1 = N,S,W,E
+# 2 = N,NE,E,SE, ...
+# 3 = N,NNE,NE,ENE,E, ...
+
+PreciseHDG=3


### PR DESCRIPTION
This feature adds an additional heading at the end of the callout.

Exmples:
200 m / 600 ft HDG 246(WSW)
200 m / 600 ft HDG 2(N)
The detail is definable in the Settings.txt and can be turned of there
